### PR TITLE
Update EncryptAspect.cs

### DIFF
--- a/Extensions/SoftFluent.EncryptAspect/SoftFluent.Samples.EncryptAspect.Aspects/EncryptAspect.cs
+++ b/Extensions/SoftFluent.EncryptAspect/SoftFluent.Samples.EncryptAspect.Aspects/EncryptAspect.cs
@@ -155,7 +155,7 @@ namespace CodeFluent.Aspects.Encrypt
                         procedureSetStatement.As = new ProcedureExpressionStatement(procedureSetStatement, ProcedureExpressionStatement.CreateLiteral(procedureSetStatement.LeftExpression.RefColumn.Column.Name));    
                     }
                     
-                    procedureExpressionStatement.LeftExpression.Literal = ProcedureExpressionStatement.CreateLiteral(string.Format("CONVERT(nvarchar, DECRYPTBYPASSPHRASE(@{0}, {1}))", PassPhraseParameterName, procedureExpressionStatement.LeftExpression.RefColumn.Column.Name));
+                    procedureExpressionStatement.LeftExpression.Literal = ProcedureExpressionStatement.CreateLiteral(string.Format("CONVERT(nvarchar(max), DECRYPTBYPASSPHRASE(@{0}, {1}))", PassPhraseParameterName, procedureExpressionStatement.LeftExpression.RefColumn.Column.Name));
                     procedureExpressionStatement.LeftExpression.RefColumn = null;
                 }
             });


### PR DESCRIPTION
In the Decryption code, Changed SQL "nvarchar" to "nvarchar(max)".
This is done to properly decrypt any values with over 30 characters,
as by default it can only correctly decrypt 30 or less characters, 
due to nvarchar defaulting to 30 characters length.

Previously, any attempted decryption of characters longer then 30 characters would only decrypt and return the first 30 characters, i.e. returns a truncated value. This is especially apparent in cases of encrypting GUIDs, which is by default 32 characters.